### PR TITLE
I've made some changes to the way buttons are created and a bug I found with the callback timer.

### DIFF
--- a/TaskDialog/TaskDialogViewModel.cs
+++ b/TaskDialog/TaskDialogViewModel.cs
@@ -455,11 +455,13 @@ namespace TaskDialogInterop
 						&& options.CommonButtons == TaskDialogCommonButtons.None)
 					{
 						_normalButtons = new List<TaskDialogButtonData>();
-						_normalButtons.Add(new TaskDialogButtonData(
-							(int)VistaTaskDialogCommonButtons.Close,
-							VistaTaskDialogCommonButtons.Close.ToString(),
-							NormalButtonCommand,
-							true, true));
+						
+						if(!ShowProgressBar)
+							_normalButtons.Add(new TaskDialogButtonData(
+								(int)VistaTaskDialogCommonButtons.Close,
+								VistaTaskDialogCommonButtons.Close.ToString(),
+								NormalButtonCommand,
+								true, true));
 					}
 					else if (RadioButtons.Count > 0)
 					{

--- a/TaskDialog/TaskDialogViewModel.cs
+++ b/TaskDialog/TaskDialogViewModel.cs
@@ -748,6 +748,12 @@ namespace TaskDialogInterop
 		/// </summary>
 		public void NotifyClosed()
 		{
+			if (options.EnableCallbackTimer) 
+			{
+				_callbackTimer.Stop();
+				_callbackTimer.IsEnabled = false;
+			}
+
 			var args = new VistaTaskDialogNotificationArgs();
 
 			args.Config = this.options;


### PR DESCRIPTION
The button change (could be rejected) as it's pretty specific.. Someone may want to not show any buttons (in the progress dialog format)..

I haven't verified that this is an issue with the native implementation.
